### PR TITLE
fix: IpRateLimit未注入IProcessingStrategy导致启动时报错

### DIFF
--- a/Admin.Core/Extensions/RateLimitServiceCollectionExtensions.cs
+++ b/Admin.Core/Extensions/RateLimitServiceCollectionExtensions.cs
@@ -27,15 +27,13 @@ namespace Admin.Core.Extensions
                 //redis
                 var redisRateLimit = new CSRedis.CSRedisClient(cacheConfig.Redis.ConnectionStringRateLimit);
                 services.AddSingleton<IDistributedCache>(new CSRedisCache(redisRateLimit));
-                services.AddSingleton<IIpPolicyStore, DistributedCacheIpPolicyStore>();
-                services.AddSingleton<IRateLimitCounterStore, DistributedCacheRateLimitCounterStore>();
+                services.AddDistributedRateLimiting();
             }
             else
             {
                 //内存
                 services.AddMemoryCache();
-                services.AddSingleton<IIpPolicyStore, MemoryCacheIpPolicyStore>();
-                services.AddSingleton<IRateLimitCounterStore, MemoryCacheRateLimitCounterStore>();
+                services.AddInMemoryRateLimiting();
             }
             services.AddSingleton<IRateLimitConfiguration, RateLimitConfiguration>();
 


### PR DESCRIPTION
AspNetCoreRateLimit更新到新版后，IpRateLimit启用时，未注入IProcessingStrategy导致启动时报错