### PR TITLE
文件服务在未启用oss时，需要注册IOSSServiceFactory，配置的注入方式也需要修改添加IOptions接口

### DIFF
--- a/src/platform/ZhonTai.Admin/Core/Extensions/OSSExtensions.cs
+++ b/src/platform/ZhonTai.Admin/Core/Extensions/OSSExtensions.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Options;
 using Minio;
 using OnceMi.AspNetCore.OSS;
+using System.Linq;
 using ZhonTai.Admin.Core.Configs;
 using OSSOptions = ZhonTai.Admin.Core.Configs.OSSOptions;
 
@@ -43,7 +44,8 @@ public static class OSSExtensions
     public static IServiceCollection AddOSS(this IServiceCollection services)
     {
         var oSSConfig = services.BuildServiceProvider().GetRequiredService<IOptions<OSSConfig>>().Value;
-        if (oSSConfig.OSSConfigs?.Count > 0)
+
+        if (oSSConfig.OSSConfigs != null && oSSConfig.OSSConfigs.Any(s => s.Enable))
         {
             foreach (var oSSOptions in oSSConfig.OSSConfigs)
             {
@@ -64,6 +66,14 @@ public static class OSSExtensions
                     CreateBucketName(oSSServiceFactory, oSSOptions);
                 }
             }
+        }
+        else
+        {
+            //未启用OSS注入
+            services.AddOSSService(option =>
+            {
+                option.Provider = OSSProvider.Invalid;
+            });
         }
 
         return services;

--- a/src/platform/ZhonTai.Admin/Services/File/FileService.cs
+++ b/src/platform/ZhonTai.Admin/Services/File/FileService.cs
@@ -19,6 +19,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Collections.Generic;
 using ZhonTai.Admin.Core.Helpers;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Options;
 
 namespace ZhonTai.Admin.Services.File;
 
@@ -37,13 +38,13 @@ public class FileService : BaseService, IFileService, IDynamicApi
     public FileService(
         IFileRepository fileRep,
         IOSSServiceFactory oSSServiceFactory,
-        OSSConfig oSSConfig,
+        IOptions<OSSConfig> oSSConfig,
         IHttpContextAccessor httpContextAccessor
     )
     {
         _fileRep = fileRep;
         _oSSServiceFactory = oSSServiceFactory;
-        _oSSConfig = oSSConfig;
+        _oSSConfig = oSSConfig.Value;
         _httpContextAccessor = httpContextAccessor;
     }
 


### PR DESCRIPTION
现在默认情况下，未启用oss，访问文件管理的时候会报错：An exception was thrown while activating Castle.Proxies.FileServiceProxy
没有可用的OSS也需要注册下OnceMi.AspNetCore.OSS所需要的服务
![MXZEH92JISV}R2RTM_QU }3](https://github.com/zhontai/Admin.Core/assets/15975059/e603fbaf-2d37-491c-b4e7-1ca67c014e88)
