### PR TITLE
修复角色名称大写字母查询不到数据的问题

### DIFF
--- a/ui/zhontai.ui.admin.vue3/src/utils/tree.ts
+++ b/ui/zhontai.ui.admin.vue3/src/utils/tree.ts
@@ -122,7 +122,7 @@ export function filterTree(tree: any = [], keyword: string, options = {}) {
     {
       children: 'children',
       filterWhere: (item: any, word: string) => {
-        return item.name?.toLocaleLowerCase().indexOf(word) > -1
+        return item.name?.toLocaleLowerCase().indexOf(word?.toLocaleLowerCase()) > -1
       },
     },
     options || {}


### PR DESCRIPTION
修复为关键词转小写比较