### PR TITLE
修复: 将 swaggerResourcePaths 从 'doc/admin' 改为 'doc/sys' 以匹配接口前缀

### DIFF
--- a/ui/zhontai.ui.admin.vue3/src/views/admin/api/index.vue
+++ b/ui/zhontai.ui.admin.vue3/src/views/admin/api/index.vue
@@ -332,7 +332,7 @@ const syncApi = async (swaggerResource: any) => {
 
 const onSync = async () => {
   state.syncLoading = true
-  const swaggerResourcePaths = ['doc/admin']
+  const swaggerResourcePaths = ['doc/sys']
   // const swaggerResourcePaths = ['doc/app']
   const swaggerResourceUrls = swaggerResourcePaths?.map((path) => `/${path}/swagger-resources`) as string[]
   const lastSwaggerResourcesIndex = swaggerResourceUrls.length - 1


### PR DESCRIPTION
新的模板使用的 sys 的前缀，导致后台页面同步接口出错