### PR TITLE
修复一个人有多个部门的的权限问题

### DIFF
--- a/src/modules/admin/ZhonTai.Admin/Services/User/UserService.cs
+++ b/src/modules/admin/ZhonTai.Admin/Services/User/UserService.cs
@@ -375,10 +375,18 @@ public partial class UserService : BaseService, IUserService, IDynamicApi
                 //本部门和下级部门
                 else if (dataScope == DataScope.DeptWithChild)
                 {
+                    // 主属部门，往下递归
                     orgIds = await _orgRep.Value
                     .Where(a => a.Id == orgId)
                     .AsTreeCte()
                     .ToListAsync(a => a.Id);
+
+                    // 处理一个用户有多个部门，只能授权当级部门，不往下递归
+                    var userOrgIds = await _userOrgRep
+                    .Where(x => x.UserId == User.Id)
+                    .ToListAsync(x => x.OrgId);
+
+                    orgIds.AddRange(userOrgIds);
                 }
 
                 //指定部门


### PR DESCRIPTION
若 [user001]

部门 = [中台/开发部/产品小组;中台/开发部/设计小组;]
主属部门 = [中台/开发部/产品小组;]
角色数据权限，如果是 [本部门 + 下级部门]

用 [user001] 登录系统后，调用 api/admin/org/get-list 时，[User.DataPermission.OrgIds].Count = 0

调试后发现 OrgIds 该值 只会在 [数据权限] 选择 [指定部门] 时候才会有值
但，这并不符合预期，预期 应该出来2个部门;

有一个巧妙的修改意见:
DataScope.Dept 时，只返回 主属部门，且不往下递归，且不处理多部门（原有逻辑不变）
DataScope.DeptWithChild 时 ，主属部门.AsTreeCte() + user_org(多部门就不递归),两者取并集
